### PR TITLE
[COREV][Zc] Add test for march args being passed.

### DIFF
--- a/gcc/testsuite/ChangeLog
+++ b/gcc/testsuite/ChangeLog
@@ -1,3 +1,17 @@
+2022-08-15  Charlie Keaney  <charlie.keaney@embecosm.com>
+
+	* gcc.target/riscv/zc-zca-arch.c: New test for march args
+	being passed from compiler to assembler.
+	* gcc.target/riscv/zc-zcb-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcb-m-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcb-zba-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcf-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcb-zbb-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcmb-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcmp-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcmpe-arch.c: Likewise.
+	* gcc.target/riscv/zc-zcmt-arch.c: Likewise.
+
 2022-04-21  Segher Boessenkool  <segher@kernel.crashing.org>
 
 	PR target/103197

--- a/gcc/testsuite/gcc.target/riscv/zc-zca-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zca-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zca -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.sw x9, 32(x10)");
+}
+
+/* { dg-final { scan-assembler "c.sw x9, 32\\(x10\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcb-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcb-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.lbu x9,1(x8)");
+}
+
+/* { dg-final { scan-assembler "c.lbu x9,1\\(x8\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcb-m-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcb-m-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32im_zcb -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.lbu x9,1(x8)");
+}
+
+/* { dg-final { scan-assembler "c.lbu x9,1\\(x8\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcb-zba-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcb-zba-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb_zba -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.lbu x9,1(x8)");
+}
+
+/* { dg-final { scan-assembler "c.lbu x9,1\\(x8\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcb-zbb-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcb-zbb-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb_zbb -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.lbu x9,1(x8)");
+}
+
+/* { dg-final { scan-assembler "c.lbu x9,1\\(x8\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcf-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcf-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcf -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.flw fa0, 0(a0)");
+}
+
+/* { dg-final { scan-assembler "c.flw fa0, 0\\(a0\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcmb-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcmb-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb_zcmb -mabi=ilp32" } */
+
+int foo()
+{
+    asm("c.lbu x9,1(x8)");
+}
+
+/* { dg-final { scan-assembler "c.lbu x9,1\\(x8\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcmp-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcmp-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb_zcmp -mabi=ilp32" } */
+
+int foo()
+{
+    asm("cm.push {ra,s0-s3},-32");
+}
+
+/* { dg-final { scan-assembler "cm.push {ra,s0-s3},-32" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcmpe-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcmpe-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_zcb_zcmpe -mabi=ilp32e" } */
+
+int foo()
+{
+    asm("cm.push {ra,s0-s3},-32");
+}
+
+/* { dg-final { scan-assembler "cm.push {ra,s0-s3},-32" } } */

--- a/gcc/testsuite/gcc.target/riscv/zc-zcmt-arch.c
+++ b/gcc/testsuite/gcc.target/riscv/zc-zcmt-arch.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32im_zcmt -mabi=ilp32" } */
+
+int foo()
+{
+    asm("cm.jt 0");
+}
+
+/* { dg-final { scan-assembler "cm.jt 0" } } */


### PR DESCRIPTION
	* gcc.target/riscv/zc-zca-arch.c: New test for march args
	being passed from compiler to assembler.
	* gcc.target/riscv/zc-zcb-arch.c: Likewise.
	* gcc.target/riscv/zc-zcb-m-arch.c: Likewise.
	* gcc.target/riscv/zc-zcb-zba-arch.c: Likewise.
	* gcc.target/riscv/zc-zcf-arch.c: Likewise.
	* gcc.target/riscv/zc-zcf-zbb-arch.c: Likewise.
	* gcc.target/riscv/zc-zcmb-arch.c: Likewise.
	* gcc.target/riscv/zc-zcmp-arch.c: Likewise.
	* gcc.target/riscv/zc-zcmpe-arch.c: Likewise.
	* gcc.target/riscv/zc-zcmt-arch.c: Likewise.